### PR TITLE
Logging, server, for Windows

### DIFF
--- a/windows-install/Install-CircleCIRunner.ps1
+++ b/windows-install/Install-CircleCIRunner.ps1
@@ -85,6 +85,8 @@ Write-Host "Preparing a config template for CircleCI Launch Agent"
 @"
 api:
   auth_token: "" # FIXME: Specify your runner token
+  # On server, set url to the hostname of your server installation. For example,
+  # url: https://circleci.example.com
 runner:
   name: "" # FIXME: Specify the name of this runner instance
   mode: single-task


### PR DESCRIPTION
This will enable launch-agent on Windows to:
1. output logs to a standard file, for better debuggability, and
2. communicate with self-hosted CircleCI server.