### PR TITLE
Add download script for launch-agent [RT-204]

### DIFF
--- a/download-launch-agent.sh
+++ b/download-launch-agent.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Set up runner directory
 prefix=/opt/circleci
 sudo mkdir -p "${prefix}/workdir"
-[[ -z ${runner_url+z} ]] && runner_url="https://runner.circleci.com"
+[[ -z ${api_url+z} ]] && api_url="https://runner.circleci.com"
 [[ -z ${agent_version+z} ]] && agent_version=""
 [[ -z ${platform+z} ]] && echo "platform not defined" && exit 1
 [[ -z ${CIRCLECI_RUNNER_TOKEN+z} ]] && echo "CIRCLECI_RUNNER_TOKEN not defined" && exit 1
@@ -15,15 +15,15 @@ echo "Using CircleCI Launch Agent version ${agent_version}"
 echo "Downloading and verifying CircleCI Launch Agent Binary"
 
 IFS="/" read -r -a split_platform <<<"${platform}"
-download_response=$(curl -H "Authorization: Bearer ${CIRCLECI_RUNNER_TOKEN}" -H "Accept: application/json" -H "Content-Type: application/json" --data "{\"os\":\"${split_platform[0]}\", \"arch\":\"${split_platform[1]}\", \"version\":\"${agent_version}\"}" --request GET ${runner_url}/api/v2/launch-agent/download)
-url=$(echo "${download_response}" | jq -r .url)
+download_response=$(curl -H "Authorization: Bearer ${CIRCLECI_RUNNER_TOKEN}" -H "Accept: application/json" -H "Content-Type: application/json" --data "{\"os\":\"${split_platform[0]}\", \"arch\":\"${split_platform[1]}\", \"version\":\"${agent_version}\"}" --request GET ${api_url}/api/v2/launch-agent/download)
+download_url=$(echo "${download_response}" | jq -r .url)
 checksum=$(echo "${download_response}" | jq -r .checksum)
 
-IFS="/" read -r -a split_url <<<"${url}"
-file=${split_url[${#split_url[@]} - 1]}
+IFS="/" read -r -a split_download_url <<<"${download_url}"
+file=${split_download_url[${#split_download_url[@]} - 1]}
 mkdir -p "${platform}"
 echo "Downloading CircleCI Launch Agent: ${file}"
-curl --compressed -L "${url}" -o "${file}"
+curl --compressed -L "${download_url}" -o "${file}"
 
 # Verifying download
 echo "Verifying CircleCI Launch Agent download"

--- a/download-launch-agent.sh
+++ b/download-launch-agent.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 # Set up runner directory
 prefix=/opt/circleci
 sudo mkdir -p "${prefix}/workdir"
+[[ -z ${runner_url+z} ]] && echo "\${runner_url} not defined setting default" && runner_url="https://runner.circleci.com" 
+[[ -z ${agent_version+z} ]] && agent_version="" 
 
 # Downloading launch agent
 echo "Using CircleCI Launch Agent version ${agent_version}"
@@ -12,13 +14,12 @@ echo "Downloading and verifying CircleCI Launch Agent Binary"
 
 split_platform=(${platform//// })
 echo ${split_platform[0]}
-echo ${split_platform[1]}
-runner_url="https://runner.circleci.com"
 download_response=$(curl -H "Accept: application/json" -H "Content-Type: application/json" --data "{\"os\":\"${split_platform[0]}\", \"arch\":\"${split_platform[1]}\"}" --request GET ${runner_url}/api/v2/runner/download)
 url=$(echo ${download_response} | jq -r .url)
 checksum=$(echo ${download_response} | jq -r .checksum)
 
-file=circleci-agent
+split_url=(${url//// })
+file=${split_url[${#split_url[@]}-1]}
 mkdir -p "${platform}"
 echo "Downloading CircleCI Launch Agent: ${file}"
 curl --compressed -L "${url}" -o "${file}"

--- a/download-launch-agent.sh
+++ b/download-launch-agent.sh
@@ -9,13 +9,20 @@ sudo mkdir -p "${prefix}/workdir"
 # Downloading launch agent
 echo "Using CircleCI Launch Agent version ${agent_version}"
 echo "Downloading and verifying CircleCI Launch Agent Binary"
-base_url="https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent"
-curl -sSL "${base_url}/${agent_version}/checksums.txt" -o checksums.txt
-file="$(grep "${platform}/circleci-launch-agent$" checksums.txt | cut -d ' ' -f 2 | sed 's/^.//')"
+
+split_platform=(${platform//// })
+echo ${split_platform[0]}
+echo ${split_platform[1]}
+runner_url="https://runner.circleci.com"
+download_response=$(curl -H "Accept: application/json" -H "Content-Type: application/json" --data "{\"os\":\"${split_platform[0]}\", \"arch\":\"${split_platform[1]}\"}" --request GET ${runner_url}/api/v2/runner/download)
+url=$(echo ${download_response} | jq -r .url)
+checksum=$(echo ${download_response} | jq -r .checksum)
+
+file=circleci-agent
 mkdir -p "${platform}"
 echo "Downloading CircleCI Launch Agent: ${file}"
-curl --compressed -L "${base_url}/${agent_version}/${file}" -o "${file}"
+curl --compressed -L "${url}" -o "${file}"
 
 # Verifying download
 echo "Verifying CircleCI Launch Agent download"
-grep "${file}$" checksums.txt | sha256sum --check && chmod +x "${file}"; sudo cp "${file}" "${prefix}/circleci-launch-agent" || echo "Invalid checksum for CircleCI Launch Agent, please try download again"
+echo "${checksum} ${file}" | sha256sum --check && chmod +x "${file}"; sudo cp "${file}" "${prefix}/circleci-launch-agent" || echo "Invalid checksum for CircleCI Launch Agent, please try download again"

--- a/download-launch-agent.sh
+++ b/download-launch-agent.sh
@@ -8,13 +8,16 @@ sudo mkdir -p "${prefix}/workdir"
 [[ -z ${runner_url+z} ]] && runner_url="https://runner.circleci.com"
 [[ -z ${agent_version+z} ]] && agent_version=""
 [[ -z ${platform+z} ]] && echo "platform not defined" && exit 1
+[[ -z ${CIRCLECI_RUNNER_TOKEN+z} ]] && echo "CIRCLECI_RUNNER_TOKEN not defined" && exit 1
+
 
 # Downloading launch agent
 echo "Using CircleCI Launch Agent version ${agent_version}"
 echo "Downloading and verifying CircleCI Launch Agent Binary"
 
 IFS="/" read -r -a split_platform <<<"${platform}"
-download_response=$(curl -H "Accept: application/json" -H "Content-Type: application/json" --data "{\"os\":\"${split_platform[0]}\", \"arch\":\"${split_platform[1]}\"}" --request GET ${runner_url}/api/v2/runner/download)
+download_response=$(curl -H "Authorization: Bearer ${CIRCLECI_RUNNER_TOKEN}" -H "Accept: application/json" -H "Content-Type: application/json" --data "{\"os\":\"${split_platform[0]}\", \"arch\":\"${split_platform[1]}\", \"version\":\"${agent_version}\"}" --request GET ${runner_url}/api/v2/launch-agent/download)
+echo ${download_response}
 url=$(echo "${download_response}" | jq -r .url)
 checksum=$(echo "${download_response}" | jq -r .checksum)
 

--- a/download-launch-agent.sh
+++ b/download-launch-agent.sh
@@ -20,7 +20,7 @@ download_url=$(echo "${download_response}" | jq -r .url)
 checksum=$(echo "${download_response}" | jq -r .checksum)
 
 IFS="/" read -r -a split_download_url <<<"${download_url}"
-file=${split_download_url[${#split_download_url[@]} - 1]}
+file="${platform}/${split_download_url[${#split_download_url[@]} - 1]}"
 mkdir -p "${platform}"
 echo "Downloading CircleCI Launch Agent: ${file}"
 curl --compressed -L "${download_url}" -o "${file}"

--- a/download-launch-agent.sh
+++ b/download-launch-agent.sh
@@ -10,14 +10,12 @@ sudo mkdir -p "${prefix}/workdir"
 [[ -z ${platform+z} ]] && echo "platform not defined" && exit 1
 [[ -z ${CIRCLECI_RUNNER_TOKEN+z} ]] && echo "CIRCLECI_RUNNER_TOKEN not defined" && exit 1
 
-
 # Downloading launch agent
 echo "Using CircleCI Launch Agent version ${agent_version}"
 echo "Downloading and verifying CircleCI Launch Agent Binary"
 
 IFS="/" read -r -a split_platform <<<"${platform}"
 download_response=$(curl -H "Authorization: Bearer ${CIRCLECI_RUNNER_TOKEN}" -H "Accept: application/json" -H "Content-Type: application/json" --data "{\"os\":\"${split_platform[0]}\", \"arch\":\"${split_platform[1]}\", \"version\":\"${agent_version}\"}" --request GET ${runner_url}/api/v2/launch-agent/download)
-echo ${download_response}
 url=$(echo "${download_response}" | jq -r .url)
 checksum=$(echo "${download_response}" | jq -r .checksum)
 

--- a/download-launch-agent.sh
+++ b/download-launch-agent.sh
@@ -5,25 +5,26 @@ set -euo pipefail
 # Set up runner directory
 prefix=/opt/circleci
 sudo mkdir -p "${prefix}/workdir"
-[[ -z ${runner_url+z} ]] && echo "\${runner_url} not defined setting default" && runner_url="https://runner.circleci.com" 
-[[ -z ${agent_version+z} ]] && agent_version="" 
+[[ -z ${runner_url+z} ]] && runner_url="https://runner.circleci.com"
+[[ -z ${agent_version+z} ]] && agent_version=""
+[[ -z ${platform+z} ]] && echo "platform not defined" && exit 1
 
 # Downloading launch agent
 echo "Using CircleCI Launch Agent version ${agent_version}"
 echo "Downloading and verifying CircleCI Launch Agent Binary"
 
-split_platform=(${platform//// })
-echo ${split_platform[0]}
+IFS="/" read -r -a split_platform <<<"${platform}"
 download_response=$(curl -H "Accept: application/json" -H "Content-Type: application/json" --data "{\"os\":\"${split_platform[0]}\", \"arch\":\"${split_platform[1]}\"}" --request GET ${runner_url}/api/v2/runner/download)
-url=$(echo ${download_response} | jq -r .url)
-checksum=$(echo ${download_response} | jq -r .checksum)
+url=$(echo "${download_response}" | jq -r .url)
+checksum=$(echo "${download_response}" | jq -r .checksum)
 
-split_url=(${url//// })
-file=${split_url[${#split_url[@]}-1]}
+IFS="/" read -r -a split_url <<<"${url}"
+file=${split_url[${#split_url[@]} - 1]}
 mkdir -p "${platform}"
 echo "Downloading CircleCI Launch Agent: ${file}"
 curl --compressed -L "${url}" -o "${file}"
 
 # Verifying download
 echo "Verifying CircleCI Launch Agent download"
-echo "${checksum} ${file}" | sha256sum --check && chmod +x "${file}"; sudo cp "${file}" "${prefix}/circleci-launch-agent" || echo "Invalid checksum for CircleCI Launch Agent, please try download again"
+echo "${checksum} ${file}" | sha256sum --check && chmod +x "${file}"
+sudo cp "${file}" "${prefix}/circleci-launch-agent" || echo "Invalid checksum for CircleCI Launch Agent, please try download again"

--- a/download-launch-agent.sh
+++ b/download-launch-agent.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Set up runner directory
+prefix=/opt/circleci
+sudo mkdir -p "${prefix}/workdir"
+
+# Downloading launch agent
+echo "Using CircleCI Launch Agent version ${agent_version}"
+echo "Downloading and verifying CircleCI Launch Agent Binary"
+base_url="https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent"
+curl -sSL "${base_url}/${agent_version}/checksums.txt" -o checksums.txt
+file="$(grep "${platform}/circleci-launch-agent$" checksums.txt | cut -d ' ' -f 2 | sed 's/^.//')"
+mkdir -p "${platform}"
+echo "Downloading CircleCI Launch Agent: ${file}"
+curl --compressed -L "${base_url}/${agent_version}/${file}" -o "${file}"
+
+# Verifying download
+echo "Verifying CircleCI Launch Agent download"
+grep "${file}$" checksums.txt | sha256sum --check && chmod +x "${file}"; sudo cp "${file}" "${prefix}/circleci-launch-agent" || echo "Invalid checksum for CircleCI Launch Agent, please try download again"


### PR DESCRIPTION
Add the download script from the runner installations docs: https://circleci.com/docs/2.0/runner-installation/#download-the-launch-agent-binary-and-verify-the-checksum

This version of the script has been slightly modified to handle multiple files under the same platform directory in the `checksums.txt` file so that it only downloads the target binary.

It has also been updated to use the Runner API to determine the version of launch-agent to use.

Jira: https://circleci.atlassian.net/browse/RT-204

Testing: https://circleci.atlassian.net/browse/RT-204?focusedCommentId=167450