### PR TITLE
[RT-316] Add script from docs to download launch agent

### DIFF
--- a/download-launch-agent.sh
+++ b/download-launch-agent.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+set -eu pipefail
+
+echo "Installing CircleCI Runner for ${platform}"
+
+base_url="https://circleci-binary-releases.s3.amazonaws.com/circleci-launch-agent"
+if [ -z ${agent_version+x} ]; then
+  agent_version=$(curl "${base_url}/release.txt")
+fi
+
+# Set up runner directory
+echo "Setting up CircleCI Runner directory"
+prefix=/opt/circleci
+sudo mkdir -p "${prefix}/workdir"
+
+# Downloading launch agent
+echo "Using CircleCI Launch Agent version ${agent_version}"
+echo "Downloading and verifying CircleCI Launch Agent Binary"
+curl -sSL "${base_url}/${agent_version}/checksums.txt" -o checksums.txt
+file="$(grep -F "${platform}" checksums.txt | cut -d ' ' -f 2 | sed 's/^.//')"
+mkdir -p "${platform}"
+echo "Downloading CircleCI Launch Agent: ${file}"
+curl --compressed -L "${base_url}/${agent_version}/${file}" -o "${file}"
+
+# Verifying download
+echo "Verifying CircleCI Launch Agent download"
+grep "${file}" checksums.txt | sha256sum --check && chmod +x "${file}"
+sudo cp "${file}" "${prefix}/circleci-launch-agent" || echo "Invalid checksum for CircleCI Launch Agent, please try download again"


### PR DESCRIPTION
Version controls the script from the docs: https://circleci.com/docs/2.0/runner-installation/#installation

Adds a bit more logging and now automatically gets the `agent_version`, unless on server.

Note: This PR differs slightly from https://github.com/CircleCI-Public/runner-installation-files/pull/2 in that it doesn't use the distributor API for getting the agent download link. This is because that method isn't supported on server yet and also introduces a couple new dependencies.