### PR TITLE
[RT-1037] Add runner agent type enforcement file

### DIFF
--- a/rhel8-install/circleci_runner_agent.te
+++ b/rhel8-install/circleci_runner_agent.te
@@ -1,0 +1,69 @@
+policy_module(circleci_runner_agent, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type circleci_runner_agent_t;
+type circleci_runner_agent_exec_t;
+init_daemon_domain(circleci_runner_agent_t, circleci_runner_agent_exec_t)
+
+permissive circleci_runner_agent_t;
+
+########################################
+#
+# circleci_runner_agent local policy
+#
+allow circleci_runner_agent_t self:fifo_file rw_fifo_file_perms;
+allow circleci_runner_agent_t self:unix_stream_socket create_stream_socket_perms;
+
+domain_use_interactive_fds(circleci_runner_agent_t)
+
+files_read_etc_files(circleci_runner_agent_t)
+
+miscfiles_read_localization(circleci_runner_agent_t)
+corenet_tcp_connect_http_port(init_t)
+userdom_exec_user_tmp_files(init_t)
+files_delete_usr_dirs(init_t)
+term_use_ptmx(init_t)
+term_use_generic_ptys(init_t)
+dev_read_sysfs(circleci_runner_agent_t)
+
+auth_login_pgm_domain(circleci_runner_agent_t)
+auth_read_passwd(circleci_runner_agent_t)
+auth_read_shadow(circleci_runner_agent_t)
+corecmd_check_exec_shell(circleci_runner_agent_t)
+corecmd_exec_bin(circleci_runner_agent_t)
+corecmd_mmap_bin_files(circleci_runner_agent_t)
+corecmd_shell_entry_type(circleci_runner_agent_t)
+corenet_tcp_connect_http_port(circleci_runner_agent_t)
+dbus_read_pid_sock_files(circleci_runner_agent_t)
+dbus_stream_connect_system_dbusd(circleci_runner_agent_t)
+files_exec_usr_files(circleci_runner_agent_t)
+files_manage_generic_tmp_dirs(circleci_runner_agent_t)
+files_map_generic_tmp_files(init_t)
+init_read_state(circleci_runner_agent_t)
+init_read_utmp(circleci_runner_agent_t)
+init_stream_connectto(circleci_runner_agent_t)
+kernel_dgram_send(circleci_runner_agent_t)
+logging_create_devlog_dev(circleci_runner_agent_t)
+logging_read_syslog_pid(circleci_runner_agent_t)
+sssd_read_public_files(circleci_runner_agent_t)
+sssd_run_stream_connect(circleci_runner_agent_t)
+sssd_search_lib(circleci_runner_agent_t)
+sssd_stream_connect(circleci_runner_agent_t)
+sudo_exec(circleci_runner_agent_t)
+sysnet_read_config(circleci_runner_agent_t)
+systemd_exec_systemctl(circleci_runner_agent_t)
+userdom_manage_user_home_content_files(circleci_runner_agent_t)
+
+allow circleci_runner_agent_t systemd_systemctl_exec_t:file map;
+allow circleci_runner_agent_t tmp_t:file { create execute rename write };
+allow circleci_runner_agent_t self:capability { setgid setuid sys_resource };
+allow circleci_runner_agent_t self:process { setpgid setrlimit setsched };
+
+allow init_t tmp_t:sock_file create;
+allow init_t tmp_t:file { execute execute_no_trans };
+allow init_t circleci_runner_agent_t:fifo_file { read write ioctl };
+allow system_dbusd_t circleci_runner_agent_t:fifo_file { read write };


### PR DESCRIPTION
Duplicate the `.te` file renaming to `circleci_runner_agent`

This will be used when installing the runner agent on SELinux machines & for RPM packaging